### PR TITLE
System_config as a kwarg for ase_atoms_to_atom_graphs

### DIFF
--- a/src/mattertune/backbones/orb/model.py
+++ b/src/mattertune/backbones/orb/model.py
@@ -315,7 +315,7 @@ class ORBBackboneModule(
         #   PR: https://github.com/orbital-materials/orb-models/pull/35
         atom_graphs = atomic_system.ase_atoms_to_atom_graphs(
             atoms,
-            self.hparams.system._to_orb_system_config(),
+            system_config = self.hparams.system._to_orb_system_config(),
             device=torch.device("cpu"),
         )
 

--- a/src/mattertune/backbones/orb/model.py
+++ b/src/mattertune/backbones/orb/model.py
@@ -315,7 +315,7 @@ class ORBBackboneModule(
         #   PR: https://github.com/orbital-materials/orb-models/pull/35
         atom_graphs = atomic_system.ase_atoms_to_atom_graphs(
             atoms,
-            system_config = self.hparams.system._to_orb_system_config(),
+            system_config=self.hparams.system._to_orb_system_config(),
             device=torch.device("cpu"),
         )
 


### PR DESCRIPTION
System_config as a kwarg for ase_atoms_to_atom_graphs
Compare [orb-models function definition](https://github.com/orbital-materials/orb-models/blob/9c7d5869c594bfb09f282ca919cbbfb3381da247/orb_models/forcefield/atomic_system.py#L91)