### PR TITLE
Update ghost LJ

### DIFF
--- a/examples/electrolyte/README.md
+++ b/examples/electrolyte/README.md
@@ -7,7 +7,7 @@ This folder contains an example calculator for a simple alchemical / ghost-ion w
 The calculator in [`ghost_target_calculator.py`](./ghost_target_calculator.py) is composed of two parts:
 
 1. A pretrained MatterTune foundation model
-2. A repulsive soft-core LJ correction from `mattertune.corrections.soft_core_lj_correction(...)`
+2. A target-environment Lennard-Jones correction from `mattertune.corrections.soft_core_lj_correction(...)`
 
 The MD driver in [`md.py`](./md.py) can also add an optional third contribution:
 
@@ -23,7 +23,7 @@ The motivation is the following:
 - For the foundation model, fully ghost target atoms are treated as if they do not exist.
 - Therefore, for the `lambda = 1` endpoint, all selected target atoms are deleted from the input `Atoms`.
 - After the model returns forces on the reduced system, the missing force rows are padded back with zeros.
-- The total `lambda = 1` endpoint still includes the soft-core correction, so the target atom's total force is generally not zero unless the correction is disabled.
+- The total `lambda = 1` endpoint still includes the ghost-endpoint LJ correction, so the target atom's total force is generally not zero unless the correction is disabled.
 
 For intermediate `0 < lambda < 1`, the example calculator uses a simple linear interpolation between the two endpoint predictions:
 
@@ -33,13 +33,19 @@ For intermediate `0 < lambda < 1`, the example calculator uses a simple linear i
 
 If we only did that deletion step, the ghost target could overlap with the environment because the base model no longer provides short-range exclusion for those target-environment pairs.
 
-To avoid that, the calculator adds a repulsive soft-core LJ correction:
+To avoid that, the calculator adds a Lennard-Jones correction only at the fully ghost endpoint:
 
 - It acts only on target-environment pairs.
 - It does not act on environment-environment pairs.
 - It does not act on target-target pairs.
 - It is derived from an explicit potential energy expression, so energy and forces remain consistent.
 - By default, the correction uses `smooth=True` so that the target can cross the cutoff without an energy or force jump.
+- The pair potential uses the classical 12-6 form
+
+`V_LJ(r) = 4 * epsilon * ((sigma / r)^12 - (sigma / r)^6)`
+
+- The real endpoint does not include this LJ term.
+- Intermediate `0 < lambda < 1` does not evaluate a separate lambda-dependent LJ term. Instead, the mixed PES is built by interpolating the real and ghost endpoint totals.
 
 In short, the total calculator is:
 
@@ -47,7 +53,7 @@ In short, the total calculator is:
 
 where the ghost-target endpoint itself is
 
-`ghost endpoint = reduced-system foundation model + target-environment soft-core correction + ghost-aware D3(reduced system)`
+`ghost endpoint = reduced-system foundation model + target-environment LJ correction + ghost-aware D3(reduced system)`
 
 and the real endpoint is
 
@@ -63,7 +69,7 @@ This lets each endpoint merge experts against its own fixed composition without 
 ## Files
 
 - [`ghost_target_calculator.py`](./ghost_target_calculator.py): the corrected ASE calculator
-- [`check_soft_core_continuity.py`](./check_soft_core_continuity.py): checks smooth-cutoff continuity and compares forces against finite-difference energy gradients
+- [`check_soft_core_continuity.py`](./check_soft_core_continuity.py): checks smooth-cutoff continuity and compares LJ forces against finite-difference energy gradients
 - [`md.py`](./md.py): runs MD with the corrected calculator
 
 ## Quick Start
@@ -186,22 +192,22 @@ Important note:
 - `lambda = 0` means "keep this target atom in the foundation-model input".
 - `lambda = 1` means "delete this target atom from the foundation-model input and treat it as a fully ghost target".
 - Intermediate `0 < lambda < 1` means "linearly interpolate between those two endpoint predictions".
-- At `lambda = 1`, the foundation-model contribution on the target atom is zero, but the total target force can still be nonzero because the soft-core correction remains active.
+- At `lambda = 1`, the foundation-model contribution on the target atom is zero, but the total target force can still be nonzero because the ghost-endpoint LJ correction remains active.
 
-### 3. Soft-core correction parameters
+### 3. LJ correction parameters
 
-- `--epsilon`: overall strength of the repulsive correction
-- `--sigma`: length scale of the correction
-- `--alpha`: soft-core denominator parameter
+- `--epsilon`: overall strength of the LJ correction
+- `--sigma`: length scale of the LJ correction
+- `--alpha`: kept for backward compatibility in the current example interface; it is not used by the present ghost-endpoint LJ implementation
 - `--rc`: cutoff radius of the correction
 - `--ro`: onset radius for the smooth cutoff
 - `--no-smooth`: disable smooth cutoff handling; by default the example uses `smooth=True`
 
 Typical meaning:
 
-- Larger `epsilon` gives a stronger excluded-volume wall.
-- Larger `sigma` makes the repulsive wall effective at longer distance.
-- `alpha` controls how soft the short-range core is.
+- Larger `epsilon` increases the overall LJ interaction strength.
+- Larger `sigma` shifts the LJ length scale outward.
+- `alpha` is currently ignored by the implemented LJ correction and is retained only to avoid breaking existing example command lines.
 - `rc` and `ro` control where the correction is turned off and how gradually it decays to zero.
 
 ### 4. Optional D3 dispersion parameters
@@ -243,7 +249,7 @@ At minimum, you should decide:
 
 1. Which pretrained model to use
 2. Which atom(s) should be ghost targets
-3. The soft-core correction scale (`epsilon`, `sigma`, `alpha`, `rc`, `ro`)
+3. The ghost-endpoint LJ correction scale (`epsilon`, `sigma`, `alpha`, `rc`, `ro`)
 4. Whether you want the additional D3 correction
 5. Whether to keep UMA MOE expert merging enabled
 6. Whether you want to initialize velocities
@@ -254,7 +260,7 @@ If you want to run from a fine-tuned MatterTune checkpoint, `--ckpt-path` is eno
 
 ## Notes
 
-- The continuity check script is useful whenever you change `epsilon`, `sigma`, `alpha`, `rc`, or `ro`.
+- The continuity check script is useful whenever you change `epsilon`, `sigma`, `rc`, or `ro`. The current LJ implementation keeps `alpha` only for backward-compatible argument parsing.
 - The corrected calculator only exposes `energy`, `forces`, and `free_energy`.
 - This example implementation lives under `examples/` on purpose. It is a demonstration layer on top of MatterTune's pretrained-model interface, not yet a formal package API.
 
@@ -269,7 +275,7 @@ Tested models:
 
 Observed behavior:
 
-- `lambda = 1` target force is not zero in the total calculator output. This is expected here, because the target-environment soft-core correction is still present at the ghost endpoint.
+- `lambda = 1` target force is not zero in the total calculator output. This is expected here, because the target-environment LJ correction is still present at the ghost endpoint.
 - For both tested models, `lambda = 0.25` matches the explicit linear interpolation between the `lambda = 0` and `lambda = 1` endpoint predictions to numerical precision.
 
 Measured interpolation residuals:
@@ -282,7 +288,7 @@ Measured `lambda = 1` target-force norm:
 - UMA `uma-s-1p1`: `1.66e-3 eV/A`
 - ORB `orb-v3-conservative-inf-omat`: `1.66e-3 eV/A`
 
-The identical `lambda = 1` target-force norm in these two tests is also expected: at the ghost endpoint, the target force comes only from the shared soft-core correction, not from the foundation model.
+The identical `lambda = 1` target-force norm in these two tests is also expected: at the ghost endpoint, the target force comes only from the shared LJ correction, not from the foundation model.
 
 D3 status:
 

--- a/examples/electrolyte/README.md
+++ b/examples/electrolyte/README.md
@@ -20,9 +20,9 @@ The motivation is the following:
 - The alchemical target identity is stored separately from the lambda values.
 - `lambda = 0` means the selected target atoms are fully real.
 - `lambda = 1` means the selected target atoms are fully ghost-like.
-- For the foundation model, fully ghost target atoms are treated as if they do not exist.
-- Therefore, for the `lambda = 1` endpoint, all selected target atoms are deleted from the input `Atoms`.
-- After the model returns forces on the reduced system, the missing force rows are padded back with zeros.
+- By default, the foundation-model ghost endpoint deletes the target atoms from the model input.
+- For pretrained MACE models, you can choose a `dummy` ghost endpoint that keeps the target atom in the graph but removes its real MACE interactions.
+- The `delete` path pads the missing force rows back with zeros after running the reduced system.
 - The total `lambda = 1` endpoint still includes the ghost-endpoint LJ correction, so the target atom's total force is generally not zero unless the correction is disabled.
 
 For intermediate `0 < lambda < 1`, the example calculator uses a simple linear interpolation between the two endpoint predictions:
@@ -54,6 +54,10 @@ In short, the total calculator is:
 where the ghost-target endpoint itself is
 
 `ghost endpoint = reduced-system foundation model + target-environment LJ correction + ghost-aware D3(reduced system)`
+
+or, for pretrained MACE with `--ghost-endpoint-mode dummy`,
+
+`ghost endpoint = dummy-target MACE endpoint + target-environment LJ correction + ghost-aware D3(reduced system)`
 
 and the real endpoint is
 
@@ -113,6 +117,32 @@ PYTHONPATH=src python examples/electrolyte/md.py \
   --steps 10
 ```
 
+To try the MACE-only dummy ghost endpoint:
+
+```bash
+cd MatterTune
+PYTHONPATH=src python examples/electrolyte/md.py \
+  --model-type mace \
+  --device cpu \
+  --ghost-endpoint-mode dummy \
+  --steps 10
+```
+
+MD runs can optionally write a per-step diagnostics file with
+`--diagnostics-name ghost_diagnostics.jsonl`. It is disabled by default.
+
+By default, the MD log prints one compact line per recorded step with:
+
+- `time_fs`
+- `temp`
+- `mixed_energy`
+- `lambda0_energy`
+- `lambda1_energy`
+- `ghost_lj`
+
+This is usually enough for production runs, while the JSONL diagnostics file is
+more useful for debugging endpoint construction details.
+
 To run MD from a MatterTune fine-tuned checkpoint instead of a pretrained model:
 
 ```bash
@@ -152,6 +182,18 @@ bash run_md.sh uma 0.25 cpu 10 1 1 pbe d3bj
 bash run_md.sh uma 0.25 cpu 10 0 0 pbe d3bj 0
 ```
 
+`run_md.sh` currently uses the same LJ defaults as `md.py`:
+
+- `epsilon = 0.00694`
+- `sigma = 2.337`
+- `alpha = 0.5`
+- `rc = 3.0`
+- `ro = 1.5`
+- `smooth = True`
+
+It currently wraps only the `uma` and `orb` examples. For pretrained MACE with
+`--ghost-endpoint-mode dummy`, run [`md.py`](./md.py) directly.
+
 The helper script arguments are:
 
 - `$1`: model family, `uma` or `orb`
@@ -184,13 +226,14 @@ To run MD with this calculator, you need to specify six groups of parameters.
 - `--lambda-array-name`: name of the `atoms.arrays[...]` field that stores the per-atom lambda values; the example default is `alchemical_lambda`
 - `--target-array-name`: name of the `atoms.arrays[...]` field that stores the explicit alchemical target mask
 - `--lambda-value`: ghost fraction assigned to the selected target atoms
+- `--ghost-endpoint-mode`: `delete` for the current reduced-system ghost endpoint, or `dummy` for the MACE dummy-atom ghost endpoint
 
 Important note:
 
 - Non-target environment atoms should keep `lambda = 0`.
 - Selected target atoms share one common lambda value in this example implementation.
 - `lambda = 0` means "keep this target atom in the foundation-model input".
-- `lambda = 1` means "delete this target atom from the foundation-model input and treat it as a fully ghost target".
+- `lambda = 1` means "evaluate the ghost endpoint for this target atom". By default this deletes the target atom from the foundation-model input; with pretrained MACE plus `--ghost-endpoint-mode dummy`, the target atom stays in the graph but its real model interactions are masked out.
 - Intermediate `0 < lambda < 1` means "linearly interpolate between those two endpoint predictions".
 - At `lambda = 1`, the foundation-model contribution on the target atom is zero, but the total target force can still be nonzero because the ghost-endpoint LJ correction remains active.
 
@@ -242,6 +285,7 @@ Important note:
 - `--output-dir`: directory for output files
 - `--trajectory-name`: ASE trajectory filename
 - `--final-structure-name`: final structure filename
+- `--diagnostics-name`: optional JSONL filename for endpoint diagnostics; disabled by default
 
 ## Choosing Parameters
 
@@ -262,33 +306,50 @@ If you want to run from a fine-tuned MatterTune checkpoint, `--ckpt-path` is eno
 
 - The continuity check script is useful whenever you change `epsilon`, `sigma`, `rc`, or `ro`. The current LJ implementation keeps `alpha` only for backward-compatible argument parsing.
 - The corrected calculator only exposes `energy`, `forces`, and `free_energy`.
+- The new `--ghost-endpoint-mode dummy` path is implemented only for pretrained MACE models.
+- The pretrained-MACE dummy path was smoke-tested locally in this repository.
 - This example implementation lives under `examples/` on purpose. It is a demonstration layer on top of MatterTune's pretrained-model interface, not yet a formal package API.
 
 ## Validation
 
-The current implementation was tested on `examples/electrolyte/data/LiH2O.xyz` with target atom `0`, `epsilon=1.0`, `sigma=1.0`, `alpha=0.5`, `rc=3.0`, `ro=1.5`, and `smooth=True`.
+The current implementation was tested on `examples/electrolyte/data/LiH2O.xyz`
+with target atom `0`, `epsilon=0.00694`, `sigma=2.337`, `alpha=0.5`,
+`rc=3.0`, `ro=1.5`, and `smooth=True`.
 
 Tested models:
 
 - `uma-s-1p1` in `uma-elec`
 - `orb-v3-conservative-inf-omat` in `orb-elec`
+- pretrained MACE `small` on CPU with `--ghost-endpoint-mode dummy`
 
 Observed behavior:
 
 - `lambda = 1` target force is not zero in the total calculator output. This is expected here, because the target-environment LJ correction is still present at the ghost endpoint.
-- For both tested models, `lambda = 0.25` matches the explicit linear interpolation between the `lambda = 0` and `lambda = 1` endpoint predictions to numerical precision.
+- Across these tests, `lambda = 0.25` matches the explicit linear interpolation between the `lambda = 0` and `lambda = 1` endpoint predictions to numerical precision.
 
 Measured interpolation residuals:
 
 - UMA `uma-s-1p1`: `|E(0.25) - [0.75 E(0) + 0.25 E(1)]| = 2.92e-7 eV`, `max|F(0.25) - [0.75 F(0) + 0.25 F(1)]| = 1.16e-6 eV/A`
 - ORB `orb-v3-conservative-inf-omat`: energy residual `0.0 eV`, force residual `7.38e-7 eV/A`
+- MACE `small` dummy endpoint: energy residual `0.0 eV`, force residual `3.13e-7 eV/A`
 
 Measured `lambda = 1` target-force norm:
 
 - UMA `uma-s-1p1`: `1.66e-3 eV/A`
 - ORB `orb-v3-conservative-inf-omat`: `1.66e-3 eV/A`
+- MACE `small` dummy endpoint: base-model target-force norm `0.0 eV/A`; the
+  total target force remains nonzero because the ghost-endpoint LJ correction is
+  still active
 
-The identical `lambda = 1` target-force norm in these two tests is also expected: at the ghost endpoint, the target force comes only from the shared LJ correction, not from the foundation model.
+The identical `lambda = 1` target-force norm in the UMA and ORB tests is also expected: at the ghost endpoint, the target force comes only from the shared LJ correction, not from the foundation model.
+
+Additional dummy-endpoint checks for pretrained MACE:
+
+- target-connected graph edges were removed in the ghost endpoint
+- the target `node_energy` contribution was removed explicitly before summing the ghost-endpoint base energy
+- the target model-force norm at the dummy endpoint was `0.0 eV/A`
+- a finite-difference check on the dummy endpoint matched the target-force
+  component to within about `2e-6 eV/A` on `LiH2O.xyz`
 
 D3 status:
 

--- a/examples/electrolyte/check_soft_core_continuity.py
+++ b/examples/electrolyte/check_soft_core_continuity.py
@@ -12,7 +12,6 @@ from mattertune.corrections import soft_core_lj_correction
 def evaluate_pair_energy_and_force(
     distance: float,
     *,
-    target_lambda: float,
     epsilon: float,
     sigma: float,
     alpha: float,
@@ -27,7 +26,6 @@ def evaluate_pair_energy_and_force(
     )
     energy, forces = soft_core_lj_correction(
         atoms,
-        target_lambda,
         target_index=0,
         epsilon=epsilon,
         sigma=sigma,
@@ -43,7 +41,6 @@ def finite_difference_force(
     distance: float,
     *,
     step: float,
-    target_lambda: float,
     epsilon: float,
     sigma: float,
     alpha: float,
@@ -52,7 +49,6 @@ def finite_difference_force(
 ) -> float:
     energy_plus, _ = evaluate_pair_energy_and_force(
         distance + step,
-        target_lambda=target_lambda,
         epsilon=epsilon,
         sigma=sigma,
         alpha=alpha,
@@ -61,7 +57,6 @@ def finite_difference_force(
     )
     energy_minus, _ = evaluate_pair_energy_and_force(
         distance - step,
-        target_lambda=target_lambda,
         epsilon=epsilon,
         sigma=sigma,
         alpha=alpha,
@@ -93,7 +88,6 @@ def main(args: argparse.Namespace) -> None:
     for distance in sample_distances:
         energy, force_x = evaluate_pair_energy_and_force(
             distance,
-            target_lambda=args.target_lambda,
             epsilon=args.epsilon,
             sigma=args.sigma,
             alpha=args.alpha,
@@ -131,7 +125,6 @@ def main(args: argparse.Namespace) -> None:
     for distance in np.linspace(args.ro + 0.1, args.rc - 0.05, args.num_gradient_points):
         energy, force_x = evaluate_pair_energy_and_force(
             distance,
-            target_lambda=args.target_lambda,
             epsilon=args.epsilon,
             sigma=args.sigma,
             alpha=args.alpha,
@@ -141,7 +134,6 @@ def main(args: argparse.Namespace) -> None:
         fd_force_x = finite_difference_force(
             distance,
             step=args.fd_step,
-            target_lambda=args.target_lambda,
             epsilon=args.epsilon,
             sigma=args.sigma,
             alpha=args.alpha,
@@ -186,7 +178,6 @@ def parse_args() -> argparse.Namespace:
         description="Check smooth-cutoff continuity and force/energy consistency for the target correction.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser.add_argument("--target-lambda", type=float, default=0.0)
     parser.add_argument("--epsilon", type=float, default=1.0)
     parser.add_argument("--sigma", type=float, default=1.0)
     parser.add_argument("--alpha", type=float, default=0.5)

--- a/examples/electrolyte/ghost_target_calculator.py
+++ b/examples/electrolyte/ghost_target_calculator.py
@@ -58,12 +58,20 @@ def _scalar_energy(value: object) -> float:
     return float(np.asarray(value, dtype=np.float64).reshape(-1)[0])
 
 
+def _force_norms(forces: np.ndarray, target_mask: np.ndarray) -> dict[str, float]:
+    return {
+        "target_force_norm_eVA": float(np.linalg.norm(forces[target_mask])),
+        "environment_force_norm_eVA": float(np.linalg.norm(forces[~target_mask])),
+        "max_force_eVA": float(np.max(np.abs(forces))) if forces.size else 0.0,
+    }
+
+
 class GhostTargetCorrectionCalculator(Calculator):
     """Interpolate between real-target and fully-ghost target endpoints.
 
     Calculator-level lambda semantics:
     - lambda = 0: the selected target atoms are fully real and remain in the model input
-    - lambda = 1: the selected target atoms are fully ghost and are deleted from the model input
+    - lambda = 1: the selected target atoms are evaluated on the configured ghost endpoint
     - 0 < lambda < 1: interpolate linearly between those two endpoint predictions
     """
 
@@ -82,6 +90,7 @@ class GhostTargetCorrectionCalculator(Calculator):
         rc: float | None = None,
         ro: float | None = None,
         smooth: bool = True,
+        ghost_endpoint_mode: str = "delete",
         use_d3: bool = False,
         d3_method: str = "pbe",
         d3_damping: str = "d3bj",
@@ -117,6 +126,11 @@ class GhostTargetCorrectionCalculator(Calculator):
             "ro": ro,
             "smooth": smooth,
         }
+        if ghost_endpoint_mode not in {"delete", "dummy"}:
+            raise ValueError(
+                "ghost_endpoint_mode must be either `delete` or `dummy`."
+            )
+        self._ghost_endpoint_mode = ghost_endpoint_mode
         self._use_d3 = use_d3
         self._d3_kwargs = {
             "method": d3_method,
@@ -124,6 +138,8 @@ class GhostTargetCorrectionCalculator(Calculator):
         }
         self._last_real_endpoint_energy: float | None = None
         self._last_ghost_endpoint_energy: float | None = None
+        self._last_real_endpoint_details: dict[str, object] | None = None
+        self._last_ghost_endpoint_details: dict[str, object] | None = None
         self.implemented_properties = ["energy", "forces", "free_energy"]
 
     @property
@@ -133,6 +149,21 @@ class GhostTargetCorrectionCalculator(Calculator):
     @property
     def last_ghost_endpoint_energy(self) -> float | None:
         return self._last_ghost_endpoint_energy
+
+    @property
+    def last_real_endpoint_details(self) -> dict[str, object] | None:
+        return copy.deepcopy(self._last_real_endpoint_details)
+
+    @property
+    def last_ghost_endpoint_details(self) -> dict[str, object] | None:
+        return copy.deepcopy(self._last_ghost_endpoint_details)
+
+    @property
+    def last_ghost_endpoint_lj_energy(self) -> float | None:
+        if self._last_ghost_endpoint_details is None:
+            return None
+        value = self._last_ghost_endpoint_details.get("lj_energy_eV")
+        return None if value is None else float(value)
 
     def check_state(self, atoms, tol=1e-15):
         system_changes = super().check_state(atoms, tol=tol)
@@ -205,23 +236,50 @@ class GhostTargetCorrectionCalculator(Calculator):
         natoms = len(full_atoms)
         full_forces = np.zeros((natoms, 3), dtype=np.float64)
         base_energy = 0.0
+        base_debug: dict[str, object] = {}
         endpoint_model = (
             self._ghost_model if ghost_targets and self._ghost_model is not None else self._model
         )
 
         if ghost_targets:
-            keep_mask = ~target_mask
-            if np.any(keep_mask):
-                reduced_atoms = _slice_atoms(full_atoms, keep_mask)
-                base_prediction = endpoint_model.predict_one(
-                    reduced_atoms,
+            use_dummy_endpoint = (
+                self._ghost_endpoint_mode == "dummy"
+                and bool(getattr(endpoint_model, "supports_dummy_endpoint", lambda: False)())
+            )
+            if self._ghost_endpoint_mode == "dummy" and not use_dummy_endpoint:
+                raise ValueError(
+                    "ghost_endpoint_mode=`dummy` requires a model that implements "
+                    "`predict_dummy_endpoint(...)`. This is currently available only "
+                    "for pretrained MACE models."
+                )
+
+            if use_dummy_endpoint:
+                base_prediction = endpoint_model.predict_dummy_endpoint(
+                    _copy_atoms(full_atoms),
+                    target_mask=target_mask,
                     properties=["energy", "forces"],
                 )
+                base_debug = copy.deepcopy(
+                    base_prediction.get("dummy_debug", {})
+                )
                 base_energy = _scalar_energy(base_prediction["energy"])
-                full_forces[keep_mask] = np.asarray(
+                full_forces[:] = np.asarray(
                     base_prediction["forces"],
                     dtype=np.float64,
                 )
+            else:
+                keep_mask = ~target_mask
+                if np.any(keep_mask):
+                    reduced_atoms = _slice_atoms(full_atoms, keep_mask)
+                    base_prediction = endpoint_model.predict_one(
+                        reduced_atoms,
+                        properties=["energy", "forces"],
+                    )
+                    base_energy = _scalar_energy(base_prediction["energy"])
+                    full_forces[keep_mask] = np.asarray(
+                        base_prediction["forces"],
+                        dtype=np.float64,
+                    )
 
             correction_energy, correction_forces = soft_core_lj_correction(
                 full_atoms,
@@ -232,6 +290,21 @@ class GhostTargetCorrectionCalculator(Calculator):
                 energy=base_energy + correction_energy,
                 forces=full_forces + correction_forces,
             )
+            endpoint_details = {
+                "mode": self._ghost_endpoint_mode,
+                "base_energy_eV": float(base_energy),
+                "lj_energy_eV": float(correction_energy),
+                "d3_energy_eV": 0.0,
+                "total_energy_eV": float(endpoint.energy),
+                "base_force_metrics": _force_norms(full_forces, target_mask),
+                "lj_force_metrics": _force_norms(correction_forces, target_mask),
+                "total_force_metrics": _force_norms(endpoint.forces, target_mask),
+                "target_atom_count": int(target_mask.sum()),
+                "model_family": endpoint_model.family,
+                "model_name": endpoint_model.model_name,
+            }
+            if base_debug:
+                endpoint_details["dummy_debug"] = base_debug
         else:
             base_prediction = endpoint_model.predict_one(
                 _copy_atoms(full_atoms),
@@ -243,6 +316,21 @@ class GhostTargetCorrectionCalculator(Calculator):
                 energy=base_energy,
                 forces=full_forces,
             )
+            endpoint_details = {
+                "mode": "real",
+                "base_energy_eV": float(base_energy),
+                "lj_energy_eV": 0.0,
+                "d3_energy_eV": 0.0,
+                "total_energy_eV": float(endpoint.energy),
+                "base_force_metrics": _force_norms(full_forces, target_mask),
+                "lj_force_metrics": _force_norms(
+                    np.zeros_like(full_forces), target_mask
+                ),
+                "total_force_metrics": _force_norms(endpoint.forces, target_mask),
+                "target_atom_count": int(target_mask.sum()),
+                "model_family": endpoint_model.family,
+                "model_name": endpoint_model.model_name,
+            }
 
         if self._use_d3:
             d3_energy, d3_forces = ghost_target_d3_correction(
@@ -255,6 +343,17 @@ class GhostTargetCorrectionCalculator(Calculator):
                 energy=endpoint.energy + d3_energy,
                 forces=endpoint.forces + d3_forces,
             )
+            endpoint_details["d3_energy_eV"] = float(d3_energy)
+            endpoint_details["d3_force_metrics"] = _force_norms(d3_forces, target_mask)
+            endpoint_details["total_energy_eV"] = float(endpoint.energy)
+            endpoint_details["total_force_metrics"] = _force_norms(
+                endpoint.forces, target_mask
+            )
+
+        if ghost_targets:
+            self._last_ghost_endpoint_details = endpoint_details
+        else:
+            self._last_real_endpoint_details = endpoint_details
 
         return endpoint
 

--- a/examples/electrolyte/ghost_target_calculator.py
+++ b/examples/electrolyte/ghost_target_calculator.py
@@ -225,7 +225,6 @@ class GhostTargetCorrectionCalculator(Calculator):
 
             correction_energy, correction_forces = soft_core_lj_correction(
                 full_atoms,
-                0.0,
                 target_mask=target_mask,
                 **self._correction_kwargs,
             )

--- a/examples/electrolyte/md.py
+++ b/examples/electrolyte/md.py
@@ -519,8 +519,8 @@ def parse_args() -> argparse.Namespace:
         default=1.0,
         help="Ghost fraction for the selected target atoms: 0 = fully real, 1 = fully ghost.",
     )
-    parser.add_argument("--epsilon", type=float, default=1.0)
-    parser.add_argument("--sigma", type=float, default=1.0)
+    parser.add_argument("--epsilon", type=float, default=0.00694)
+    parser.add_argument("--sigma", type=float, default=2.337)
     parser.add_argument("--alpha", type=float, default=0.5)
     parser.add_argument("--rc", type=float, default=3.0)
     parser.add_argument("--ro", type=float, default=1.5)

--- a/examples/electrolyte/md.py
+++ b/examples/electrolyte/md.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import copy
+import json
 import sys
 import time
 from contextlib import contextmanager
@@ -9,6 +10,7 @@ from pathlib import Path
 
 import ase.units as units
 import numpy as np
+import torch
 from ase import Atoms
 from ase.build import bulk
 from ase.io import read, write
@@ -28,6 +30,7 @@ from mattertune.backbones import (
 )
 from mattertune.finetune.base import FinetuneModuleBase
 from mattertune.pretrained import PretrainedModel
+from mattertune.util import optional_import_error_message
 
 from ghost_target_calculator import GhostTargetCorrectionCalculator
 
@@ -83,6 +86,7 @@ def annotate_frame_metadata(
     total_energy: float,
     lambda0_energy: float | None,
     lambda1_energy: float | None,
+    ghost_lj_energy: float | None,
     lambda_array_name: str,
 ):
     atoms.info["md_step"] = int(step)
@@ -95,6 +99,8 @@ def annotate_frame_metadata(
     if lambda1_energy is not None:
         atoms.info["lambda1_energy_eV"] = float(lambda1_energy)
         atoms.info["final_pes_energy_eV"] = float(lambda1_energy)
+    if ghost_lj_energy is not None:
+        atoms.info["ghost_lj_energy_eV"] = float(ghost_lj_energy)
     atoms.arrays[lambda_array_name] = np.asarray(
         atoms.arrays[lambda_array_name], dtype=np.float64
     ).copy()
@@ -108,20 +114,71 @@ def format_step_log(
     total_energy: float,
     lambda0_energy: float | None,
     lambda1_energy: float | None,
-    lambda_mask: np.ndarray,
-    max_force: float,
+    ghost_lj_energy: float | None,
 ) -> str:
     lambda0_str = "nan" if lambda0_energy is None else f"{lambda0_energy: .12f}"
     lambda1_str = "nan" if lambda1_energy is None else f"{lambda1_energy: .12f}"
+    ghost_lj_str = "nan" if ghost_lj_energy is None else f"{ghost_lj_energy: .12f}"
     return (
         f"step={step:5d} time_fs={time_fs:9.3f} "
         f"temp={temperature:8.3f} K "
-        f"energy={total_energy: .12f} eV "
+        f"mixed_energy={total_energy: .12f} eV "
         f"lambda0_energy={lambda0_str} eV "
         f"lambda1_energy={lambda1_str} eV "
-        f"max|F|={max_force:.6f} "
-        f"lambda={lambda_mask_to_string(lambda_mask)}"
+        f"ghost_lj={ghost_lj_str} eV"
     )
+
+
+def _json_ready(value):
+    if isinstance(value, dict):
+        return {str(key): _json_ready(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
+def write_diagnostics_record(
+    diagnostics_path: Path | None,
+    *,
+    model_family: str,
+    model_name: str,
+    ghost_endpoint_mode: str,
+    step: int,
+    time_fs: float,
+    lambda_mask: np.ndarray,
+    total_energy: float,
+    lambda0_energy: float | None,
+    lambda1_energy: float | None,
+    calculator: GhostTargetCorrectionCalculator,
+):
+    if diagnostics_path is None:
+        return
+
+    payload = {
+        "model_family": model_family,
+        "model_name": model_name,
+        "ghost_endpoint_mode": ghost_endpoint_mode,
+        "step": int(step),
+        "time_fs": float(time_fs),
+        "lambda_mask": np.asarray(lambda_mask, dtype=np.float64),
+        "total_energy_eV": float(total_energy),
+        "lambda0_energy_eV": None if lambda0_energy is None else float(lambda0_energy),
+        "lambda1_energy_eV": None if lambda1_energy is None else float(lambda1_energy),
+        "endpoint_gap_eV": (
+            None
+            if lambda0_energy is None or lambda1_energy is None
+            else float(lambda1_energy - lambda0_energy)
+        ),
+        "real_endpoint": calculator.last_real_endpoint_details,
+        "ghost_endpoint": calculator.last_ghost_endpoint_details,
+    }
+    diagnostics_path.parent.mkdir(parents=True, exist_ok=True)
+    with diagnostics_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(_json_ready(payload), ensure_ascii=True) + "\n")
 
 
 def build_default_atoms() -> Atoms:
@@ -197,6 +254,9 @@ class ASECalculatorBackedModel:
         self.implemented_properties = tuple(
             getattr(calculator, "implemented_properties", [])
         )
+
+    def supports_dummy_endpoint(self) -> bool:
+        return False
 
     def predict_one(
         self,
@@ -322,23 +382,19 @@ def main(args: argparse.Namespace) -> None:
     trajectory_path = output_dir / args.trajectory_name
     final_structure_path = output_dir / args.final_structure_name
     log_path = trajectory_path.with_suffix(".txt")
+    diagnostics_path = (
+        None
+        if args.diagnostics_name is None
+        else output_dir / args.diagnostics_name
+    )
 
     with tee_output(log_path):
         model, ghost_model = load_md_models(args)
         print(
-            f"loaded model: family={model.family}, name={model.model_name}, device={model.device}"
+            f"model={model.family}:{model.model_name} device={model.device} "
+            f"target_indices={target_indices} lambda={args.lambda_value:.6f} "
+            f"ghost_mode={args.ghost_endpoint_mode} use_d3={args.use_d3}"
         )
-        print(f"target indices: {target_indices}")
-        print(f"target lambda: {args.lambda_value:.6f}")
-        if should_enable_uma_merge_experts(args):
-            print("UMA MOE merge: enabled")
-            if ghost_model is not None:
-                print("UMA MOE merge: using a second predictor for the ghost endpoint")
-        elif args.model_type is not None and args.model_type.strip().lower() == "uma":
-            print("UMA MOE merge: disabled")
-        print(f"use D3 correction: {args.use_d3}")
-        if args.use_d3:
-            print(f"D3 method: {args.d3_method}, damping: {args.d3_damping}")
 
         calc = GhostTargetCorrectionCalculator(
             model,
@@ -351,21 +407,15 @@ def main(args: argparse.Namespace) -> None:
             rc=args.rc,
             ro=args.ro,
             smooth=args.smooth,
+            ghost_endpoint_mode=args.ghost_endpoint_mode,
             use_d3=args.use_d3,
             d3_method=args.d3_method,
             d3_damping=args.d3_damping,
         )
         atoms.calc = calc
 
-        initial_energy = atoms.get_potential_energy()
-        initial_forces = atoms.get_forces()
-        print(f"initial corrected energy: {initial_energy:.12f} eV")
-        print(f"initial lambda=0 energy: {calc.last_real_endpoint_energy:.12f} eV")
-        print(f"initial lambda=1 energy: {calc.last_ghost_endpoint_energy:.12f} eV")
-        print(f"initial max|F|: {np.abs(initial_forces).max():.6f} eV/A")
-        print(
-            f"initial lambda mask: {lambda_mask_to_string(np.asarray(atoms.arrays[args.lambda_array_name], dtype=np.float64))}"
-        )
+        _ = atoms.get_potential_energy()
+        _ = atoms.get_forces()
 
         if args.init_velocities:
             MaxwellBoltzmannDistribution(
@@ -390,19 +440,17 @@ def main(args: argparse.Namespace) -> None:
 
         if trajectory_path.exists():
             trajectory_path.unlink()
+        if diagnostics_path is not None and diagnostics_path.exists():
+            diagnostics_path.unlink()
 
         def record_step() -> None:
             step = dynamics.nsteps
             time_fs = step * args.timestep_fs
             energy = atoms.get_potential_energy()
-            forces = atoms.get_forces()
             temperature = atoms.get_temperature()
             lambda0_energy = calc.last_real_endpoint_energy
             lambda1_energy = calc.last_ghost_endpoint_energy
-            lambda_mask_current = np.asarray(
-                atoms.arrays[args.lambda_array_name], dtype=np.float64
-            )
-            max_force = float(np.abs(forces).max())
+            ghost_lj_energy = calc.last_ghost_endpoint_lj_energy
 
             frame = atoms.copy()
             annotate_frame_metadata(
@@ -413,6 +461,7 @@ def main(args: argparse.Namespace) -> None:
                 total_energy=energy,
                 lambda0_energy=lambda0_energy,
                 lambda1_energy=lambda1_energy,
+                ghost_lj_energy=ghost_lj_energy,
                 lambda_array_name=args.lambda_array_name,
             )
             write(
@@ -429,9 +478,23 @@ def main(args: argparse.Namespace) -> None:
                     total_energy=energy,
                     lambda0_energy=lambda0_energy,
                     lambda1_energy=lambda1_energy,
-                    lambda_mask=lambda_mask_current,
-                    max_force=max_force,
+                    ghost_lj_energy=ghost_lj_energy,
                 )
+            )
+            write_diagnostics_record(
+                diagnostics_path,
+                model_family=model.family,
+                model_name=model.model_name,
+                ghost_endpoint_mode=args.ghost_endpoint_mode,
+                step=step,
+                time_fs=time_fs,
+                lambda_mask=np.asarray(
+                    atoms.arrays[args.lambda_array_name], dtype=np.float64
+                ),
+                total_energy=energy,
+                lambda0_energy=lambda0_energy,
+                lambda1_energy=lambda1_energy,
+                calculator=calc,
             )
 
         dynamics.attach(record_step, interval=args.log_interval)
@@ -461,11 +524,14 @@ def main(args: argparse.Namespace) -> None:
             total_energy=final_energy,
             lambda0_energy=calc.last_real_endpoint_energy,
             lambda1_energy=calc.last_ghost_endpoint_energy,
+            ghost_lj_energy=calc.last_ghost_endpoint_lj_energy,
             lambda_array_name=args.lambda_array_name,
         )
         write(final_structure_path, final_frame)
         print(f"trajectory written to {trajectory_path}")
         print(f"log written to {log_path}")
+        if diagnostics_path is not None:
+            print(f"diagnostics written to {diagnostics_path}")
         print(f"final structure written to {final_structure_path}")
 
 
@@ -530,6 +596,12 @@ def parse_args() -> argparse.Namespace:
         dest="smooth",
         help="Disable the smooth cutoff for the ghost-target correction.",
     )
+    parser.add_argument(
+        "--ghost-endpoint-mode",
+        choices=("delete", "dummy"),
+        default="delete",
+        help="How to construct the ghost endpoint. `dummy` currently supports pretrained MACE models.",
+    )
     parser.set_defaults(smooth=True)
     parser.set_defaults(uma_merge_experts=True)
     parser.add_argument("--temperature", type=float, default=300.0)
@@ -546,7 +618,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--output-dir", default=str(default_output_dir))
     parser.add_argument("--trajectory-name", default="ghost_md.xyz")
     parser.add_argument("--final-structure-name", default="ghost_final.extxyz")
+    parser.add_argument(
+        "--diagnostics-name",
+        default="",
+        help="Optional JSONL file for per-step endpoint diagnostics. Set to an empty string to disable.",
+    )
     args = parser.parse_args()
+    if args.diagnostics_name == "":
+        args.diagnostics_name = None
     if args.ckpt_path is None and args.model_type is None:
         parser.error("Either --model-type or --ckpt-path must be provided.")
     return args

--- a/examples/electrolyte/run_md.sh
+++ b/examples/electrolyte/run_md.sh
@@ -59,8 +59,8 @@ PYTHONPATH=src python examples/electrolyte/md.py \
   --structure "examples/electrolyte/data/LiH2O.xyz" \
   --target-indices "0" \
   --lambda-value "${LAMBDA_VALUE}" \
-  --epsilon 1.0 \
-  --sigma 1.0 \
+  --epsilon 0.00694 \
+  --sigma 2.337 \
   --alpha 0.5 \
   --rc 3.0 \
   --ro 1.5 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "matscipy",
     "scikit-learn",
     "lightning",
-    "numpy",
+    "numpy<2",
     "torchmetrics",
     "nshconfig[extra]",
     "nshconfig-extra[extra]",
@@ -32,7 +32,7 @@ requires = [
     "setuptools >= 61.0",
     "wheel",
     "Cython",
-    "numpy"
+    "numpy<2"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/src/mattertune/corrections/soft_core_lj.py
+++ b/src/mattertune/corrections/soft_core_lj.py
@@ -39,58 +39,29 @@ def _resolve_target_mask(
     return mask
 
 
-def _resolve_target_lambdas(
-    target_lambda: float | Sequence[float] | NDArray[np.floating],
-    natoms: int,
-) -> NDArray[np.float64]:
-    if np.isscalar(target_lambda):
-        lambda_array = np.full(natoms, float(target_lambda), dtype=np.float64)
-    else:
-        lambda_array = np.asarray(target_lambda, dtype=np.float64)
-        if lambda_array.shape != (natoms,):
-            raise ValueError(
-                f"Expected target_lambda with shape ({natoms},), got {lambda_array.shape}."
-            )
-
-    if np.any(lambda_array < 0.0) or np.any(lambda_array > 1.0):
-        raise ValueError(
-            "All target lambda values must lie in the closed interval [0, 1]."
-        )
-    return lambda_array
-
-
 def _repulsive_soft_core_pair_energy(
     r2: NDArray[np.float64],
-    pair_lambda: NDArray[np.float64],
     *,
     epsilon: float,
     sigma: float,
-    alpha: float,
 ) -> NDArray[np.float64]:
     reduced_r6 = (r2 / sigma**2) ** 3
-    denominator = alpha * pair_lambda + reduced_r6
-    coupling = 1.0 - pair_lambda
-    return 4.0 * epsilon * coupling / denominator**2
+    return 4.0 * epsilon * (1.0 / reduced_r6**2 - 1.0 / reduced_r6)
 
 
 def _repulsive_soft_core_pair_force_scalar(
     r2: NDArray[np.float64],
-    pair_lambda: NDArray[np.float64],
     *,
     epsilon: float,
     sigma: float,
-    alpha: float,
 ) -> NDArray[np.float64]:
     """Return the ASE-style scalar prefactor so that F_ij = scalar * d_ij."""
     reduced_r6 = (r2 / sigma**2) ** 3
-    denominator = alpha * pair_lambda + reduced_r6
-    coupling = 1.0 - pair_lambda
-    return -48.0 * epsilon * coupling * reduced_r6 / (denominator**3 * r2)
+    return 24.0 * epsilon * (-2.0 / reduced_r6**2 + 1.0 / reduced_r6) / r2
 
 
 def soft_core_lj_correction(
     atoms: Atoms,
-    target_lambda: float | Sequence[float] | NDArray[np.floating],
     *,
     target_index: int | None = None,
     target_mask: Sequence[bool] | NDArray[np.bool_] | None = None,
@@ -103,23 +74,22 @@ def soft_core_lj_correction(
 ) -> tuple[float, NDArray[np.float64]]:
     """Compute a target-specific repulsive soft-core LJ correction.
 
-    This correction is designed for ghost-like alchemical reference states:
-    it acts only on pairs containing one explicitly selected target atom and
-    one non-target environment atom. Environment-environment pairs and
-    target-target pairs are left unchanged.
+    This correction is designed for ghost-like reference states: it acts only
+    on pairs containing one explicitly selected target atom and one non-target
+    environment atom. Environment-environment pairs and target-target pairs
+    are left unchanged.
 
-    The pair potential is a purely repulsive soft-core wall,
+    The pair potential uses the classical 12-6 Lennard-Jones form,
 
-    ``V_sc^rep(r; lambda) = 4 * epsilon * (1 - lambda) / D^2``
+    ``V_LJ(r) = 4 * epsilon * ((sigma / r)^12 - (sigma / r)^6)``.
 
-    with
+    In the electrolyte example workflow, this correction is attached only to
+    the fully ghost endpoint. Intermediate lambda values do not evaluate a
+    separate lambda-dependent LJ term; they inherit this contribution only
+    through endpoint interpolation.
 
-    ``D = alpha * lambda + (r / sigma)^6``.
-
-    Therefore:
-
-    - ``lambda = 1`` turns the correction off.
-    - ``lambda = 0`` leaves a purely repulsive excluded-volume wall.
+    ``alpha`` is retained in the public signature for backward compatibility
+    with existing example scripts, but it is not used in this ghost-only form.
 
     The implementation follows ASE ``LennardJones`` conventions for
     neighbor-list construction, pair-energy partitioning, and cutoff handling.
@@ -135,8 +105,6 @@ def soft_core_lj_correction(
     )
     if not np.any(resolved_target_mask):
         return 0.0, np.zeros((natoms, 3), dtype=np.float64)
-
-    lambda_array = _resolve_target_lambdas(target_lambda, natoms)
 
     if rc is None:
         rc = 3.0 * sigma
@@ -168,28 +136,18 @@ def soft_core_lj_correction(
         if not np.any(target_environment_mask):
             continue
 
-        active_neighbors = neighbors[target_environment_mask]
         distance_vectors = distance_vectors[target_environment_mask]
         r2 = r2[target_environment_mask]
 
-        if ii_is_target:
-            pair_lambda = lambda_array[ii] * np.ones_like(r2, dtype=np.float64)
-        else:
-            pair_lambda = lambda_array[active_neighbors]
-
         pairwise_energies = _repulsive_soft_core_pair_energy(
             r2,
-            pair_lambda,
             epsilon=epsilon,
             sigma=sigma,
-            alpha=alpha,
         )
         pairwise_forces = _repulsive_soft_core_pair_force_scalar(
             r2,
-            pair_lambda,
             epsilon=epsilon,
             sigma=sigma,
-            alpha=alpha,
         )
 
         if smooth:
@@ -202,10 +160,8 @@ def soft_core_lj_correction(
         else:
             pairwise_energies -= _repulsive_soft_core_pair_energy(
                 np.full_like(r2, rc2, dtype=np.float64),
-                pair_lambda,
                 epsilon=epsilon,
                 sigma=sigma,
-                alpha=alpha,
             )
 
         pairwise_forces = pairwise_forces[:, np.newaxis] * distance_vectors
@@ -249,7 +205,6 @@ if __name__ == "__main__":
 
     zero_energy, zero_forces = soft_core_lj_correction(
         triad,
-        0.0,
         epsilon=epsilon,
         sigma=sigma,
         alpha=alpha,
@@ -270,33 +225,8 @@ if __name__ == "__main__":
         message="No selected target atoms should give zero correction forces.",
     )
 
-    fully_coupled_energy, fully_coupled_forces = soft_core_lj_correction(
-        triad,
-        1.0,
-        target_index=0,
-        epsilon=epsilon,
-        sigma=sigma,
-        alpha=alpha,
-        rc=rc,
-        ro=ro,
-        smooth=False,
-    )
-    _assert_allclose(
-        fully_coupled_energy,
-        0.0,
-        atol=0.0,
-        message="lambda=1 should turn the correction off for the target atom.",
-    )
-    _assert_allclose(
-        fully_coupled_forces,
-        np.zeros((3, 3), dtype=np.float64),
-        atol=0.0,
-        message="lambda=1 should give zero correction forces.",
-    )
-
     target_only_energy, target_only_forces = soft_core_lj_correction(
         triad,
-        0.0,
         target_index=0,
         epsilon=epsilon,
         sigma=sigma,
@@ -308,16 +238,12 @@ if __name__ == "__main__":
     target_distances2 = np.array([1.1**2, 2.0**2], dtype=np.float64)
     expected_pair_energies = _repulsive_soft_core_pair_energy(
         target_distances2,
-        np.zeros(2, dtype=np.float64),
         epsilon=epsilon,
         sigma=sigma,
-        alpha=alpha,
     ) - _repulsive_soft_core_pair_energy(
         np.full(2, rc**2, dtype=np.float64),
-        np.zeros(2, dtype=np.float64),
         epsilon=epsilon,
         sigma=sigma,
-        alpha=alpha,
     )
     _assert_allclose(
         target_only_energy,
@@ -334,7 +260,6 @@ if __name__ == "__main__":
     )
     overlap_energy, overlap_forces = soft_core_lj_correction(
         overlap_atoms,
-        0.0,
         target_index=0,
         epsilon=epsilon,
         sigma=sigma,
@@ -350,7 +275,6 @@ if __name__ == "__main__":
 
     all_targets_energy, all_targets_forces = soft_core_lj_correction(
         overlap_atoms,
-        0.0,
         target_mask=[True, True],
         epsilon=epsilon,
         sigma=sigma,
@@ -387,7 +311,6 @@ if __name__ == "__main__":
 
     smooth_energy, smooth_forces = soft_core_lj_correction(
         overlap_atoms,
-        0.3,
         target_index=0,
         epsilon=epsilon,
         sigma=sigma,

--- a/src/mattertune/pretrained.py
+++ b/src/mattertune/pretrained.py
@@ -5,6 +5,7 @@ import logging
 from collections.abc import Sequence
 from typing import Any, Literal, TypeAlias, overload
 
+import numpy as np
 import torch
 from ase import Atoms
 from ase.calculators.calculator import Calculator, all_changes
@@ -182,6 +183,20 @@ class PretrainedModel:
     def ase_calculator(self) -> MatterTunePretrainedCalculator:
         return MatterTunePretrainedCalculator(self)
 
+    def supports_dummy_endpoint(self) -> bool:
+        return False
+
+    def predict_dummy_endpoint(
+        self,
+        atoms: Atoms,
+        *,
+        target_mask: Sequence[bool] | np.ndarray,
+        properties: Sequence[str] | None = None,
+    ) -> Prediction:
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not implement dummy-endpoint inference."
+        )
+
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(family={self.family!r}, "
@@ -222,6 +237,179 @@ class _NativeCalculatorBackedModel(PretrainedModel):
             system_changes=all_changes,
         )
         return _copy_results(self._calculator.results)
+
+
+class _MACECalculatorBackedModel(_NativeCalculatorBackedModel):
+    def __init__(
+        self,
+        *,
+        family: PretrainedFamily,
+        model_name: str,
+        device: str,
+        calculator: Calculator,
+    ):
+        super().__init__(
+            family=family,
+            model_name=model_name,
+            device=device,
+            calculator=calculator,
+        )
+
+        with optional_import_error_message("mace"):
+            from mace.tools import utils as mace_utils
+
+        if not hasattr(calculator, "models") or not calculator.models:
+            raise ValueError(
+                "The MACE pretrained calculator does not expose a loaded foundation model."
+            )
+
+        self._mace_model = calculator.models[0]
+        self._mace_model.eval()
+        atomic_numbers = getattr(self._mace_model, "atomic_numbers", None)
+        if atomic_numbers is None:
+            raise ValueError(
+                "The MACE pretrained model does not expose `atomic_numbers`."
+            )
+        self._z_table = mace_utils.AtomicNumberTable(
+            [int(z) for z in atomic_numbers]
+        )
+        self._cutoff = float(self._mace_model.r_max.detach().cpu().item())
+
+    def supports_dummy_endpoint(self) -> bool:
+        return True
+
+    @staticmethod
+    def _mask_mace_edges(batch: Any, target_mask: torch.Tensor) -> tuple[Any, dict[str, int]]:
+        edge_index: torch.Tensor = batch["edge_index"]
+        src = edge_index[0].long()
+        dst = edge_index[1].long()
+        keep_edges = (~target_mask[src]) & (~target_mask[dst])
+        num_edges = int(edge_index.shape[1])
+
+        for key, value in list(batch):
+            if not torch.is_tensor(value):
+                continue
+            if key == "edge_index":
+                batch[key] = value[:, keep_edges]
+                continue
+            if value.ndim > 0 and int(value.shape[0]) == num_edges:
+                batch[key] = value[keep_edges]
+        return batch, {
+            "total_edge_count": num_edges,
+            "kept_edge_count": int(keep_edges.sum().item()),
+            "removed_edge_count": int((~keep_edges).sum().item()),
+        }
+
+    def predict_dummy_endpoint(
+        self,
+        atoms: Atoms,
+        *,
+        target_mask: Sequence[bool] | np.ndarray,
+        properties: Sequence[str] | None = None,
+    ) -> Prediction:
+        requested = _normalize_requested_properties(properties, self.implemented_properties)
+        unsupported = sorted(set(requested) - {"energy", "forces"})
+        if unsupported:
+            raise ValueError(
+                "MACE dummy-endpoint inference currently supports only "
+                f"`energy` and `forces`, got {unsupported}."
+            )
+
+        target_array = np.asarray(target_mask, dtype=bool)
+        if target_array.shape != (len(atoms),):
+            raise ValueError(
+                f"Expected target mask with shape ({len(atoms)},), got {target_array.shape}."
+            )
+
+        with optional_import_error_message("mace"):
+            from mace import data as mace_data
+            from mace.tools.torch_geometric import Batch
+
+        atoms_copy = _copy_atoms(atoms)
+        data_config = mace_data.config_from_atoms(atoms_copy)
+        data = mace_data.AtomicData.from_config(
+            data_config,
+            z_table=self._z_table,
+            cutoff=self._cutoff,
+        )
+        setattr(
+            data,
+            "atomic_numbers",
+            torch.tensor(atoms_copy.get_atomic_numbers(), dtype=torch.long),
+        )
+        batch = Batch.from_data_list([data])
+        batch = batch.to(self.device)
+
+        target_tensor = torch.as_tensor(target_array, dtype=torch.bool, device=batch["batch"].device)
+        batch, edge_stats = self._mask_mace_edges(batch, target_tensor)
+
+        with torch.enable_grad():
+            output = self._mace_model(
+                batch.to_dict(),
+                compute_force="forces" in requested,
+                compute_stress=False,
+                training=False,
+            )
+
+        prediction: Prediction = {}
+        if "energy" in requested:
+            node_energy = output.get("node_energy")
+            if node_energy is None:
+                raise ValueError(
+                    "The MACE dummy-endpoint path requires `node_energy` so that "
+                    "dummy-target contributions can be removed explicitly."
+                )
+            node_energy = node_energy.reshape(-1)
+            energy_value = node_energy[~target_tensor].sum()
+            prediction["energy"] = float(energy_value.detach().cpu().item())
+
+        if "forces" in requested:
+            forces = output.get("forces")
+            if forces is None:
+                raise ValueError(
+                    "The MACE dummy-endpoint forward pass did not return forces."
+                )
+            forces_array = forces.detach().cpu().numpy().astype(np.float64, copy=False)
+            raw_forces_array = forces_array.copy()
+            forces_array[target_array] = 0.0
+            prediction["forces"] = forces_array
+        else:
+            raw_forces_array = None
+
+        prediction["dummy_debug"] = {
+            "has_node_energy": True,
+            "raw_total_energy_eV": float(output["energy"].detach().cpu().reshape(-1)[0].item()),
+            "masked_total_energy_eV": float(prediction["energy"]) if "energy" in prediction else None,
+            "removed_target_node_energy_eV": (
+                float(node_energy[target_tensor].sum().detach().cpu().item())
+                if "energy" in requested
+                else None
+            ),
+            "target_atom_count": int(target_tensor.sum().item()),
+            **edge_stats,
+            "raw_target_force_norm_eVA": (
+                float(np.linalg.norm(raw_forces_array[target_array]))
+                if raw_forces_array is not None
+                else None
+            ),
+            "raw_environment_force_norm_eVA": (
+                float(np.linalg.norm(raw_forces_array[~target_array]))
+                if raw_forces_array is not None
+                else None
+            ),
+            "masked_target_force_norm_eVA": (
+                float(np.linalg.norm(prediction["forces"][target_array]))
+                if "forces" in prediction
+                else None
+            ),
+            "masked_environment_force_norm_eVA": (
+                float(np.linalg.norm(prediction["forces"][~target_array]))
+                if "forces" in prediction
+                else None
+            ),
+        }
+
+        return prediction
 
 
 def _default_orb_model_name(available_names: Sequence[str]) -> str:
@@ -354,7 +542,7 @@ def _load_mace_pretrained(
         calculator = mace_mp(model=resolved_name, device=device, **kwargs)
         pretty_name = resolved_name or "medium-mpa-0"
 
-    return _NativeCalculatorBackedModel(
+    return _MACECalculatorBackedModel(
         family="mace",
         model_name=str(pretty_name),
         device=device,


### PR DESCRIPTION
## What changed

This updates the electrolyte ghost-target workflow so the ghost endpoint uses a fixed ghost-endpoint LJ correction and the intermediate states continue to come only from linear interpolation between the real and ghost endpoints.

## Why it changed

The intent of this workflow is:
- real endpoint: fully interacting target in the full system
- ghost endpoint: target removed from the model input, with an LJ exclusion term added only at the ghost endpoint
- intermediate states: linear interpolation between the two endpoint PES definitions

This avoids coupling the LJ term to lambda inside the correction itself.